### PR TITLE
Number validation

### DIFF
--- a/mobile-app/lib/screens/signup/signup_screen.dart
+++ b/mobile-app/lib/screens/signup/signup_screen.dart
@@ -20,6 +20,14 @@ class _SignupScreenState extends State<SignupScreen> {
   final _nicTEController = TextEditingController();
   final _passwordTEController = TextEditingController();
   bool _signingin = false;
+
+  @override
+  void initState() {
+    setState(() {
+      _n = 55;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     var _mediaQueryData = MediaQuery.of(context);
@@ -269,10 +277,6 @@ class _SignupScreenState extends State<SignupScreen> {
   }
 
   void _signin() {
-    setState(() {
-      _n = 55;
-    });
     Application.router.pop(context);
-
   }
 }


### PR DESCRIPTION
Add number validation

`final phoneNumber = "+94" + _phoneNumberTEController.text.toString();`
UI will only accept 9 digit numbers now. Phone number field automatically triggers the number keyboard. But in case, add a validation to check it's an integer too.  

![Screenshot_1604379808](https://user-images.githubusercontent.com/38649090/97952063-32519380-1dc2-11eb-8112-d4c9d84bc442.png)
![Screenshot_1604379820](https://user-images.githubusercontent.com/38649090/97952069-37164780-1dc2-11eb-9c00-a3f268ffc6b6.png)
![Screenshot_1604379865](https://user-images.githubusercontent.com/38649090/97952073-3aa9ce80-1dc2-11eb-9b3a-136b41f7233c.png)
![Screenshot_1604379881](https://user-images.githubusercontent.com/38649090/97952078-3da4bf00-1dc2-11eb-8171-b8ee37a2af51.png)
![Screenshot_1604380292](https://user-images.githubusercontent.com/38649090/97952086-41384600-1dc2-11eb-808f-130382652af6.png)
